### PR TITLE
dcp-669 Patch file document with data archive result

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,34 +26,59 @@ E.g. 1 Without `files` property.
 E.g. 2
 ```
 {
-   "sub_uuid":"6e6097bc-b23e-4f09-86a8-8a5a0fc06113",
+   "sub_uuid": "6e6097bc-b23e-4f09-86a8-8a5a0fc06113",
    "files":[
-      "read1.fq",
-      "read2.fq"
+      "f5e465ca-543e-44f5-9045-aebce6eb9ac3",
+      "4320dc71-ac5f-4cb3-b1d3-d9a253a59e3b",
+      ...
    ]
 }
 ```
 
 
 ## Data archiving result
+
+E.g. 1 
 ```
 {
-   "sub_uuid":"6e6097bc-b23e-4f09-86a8-8a5a0fc06113",
-   "success":true,
-   "error":"msg",
+   "sub_uuid": "6e6097bc-b23e-4f09-86a8-8a5a0fc06113",
+   "success": false,
+   "error": "No sequence files in submission",
+   "files":[]
+}
+
+```
+
+E.g. 2
+```
+{
+   "sub_uuid": "6e6097bc-b23e-4f09-86a8-8a5a0fc06113",
+   "success": true,
+   "error": null,
    "files":[
       {
-         "file_name":"read1.fq",
-         "md5":"098f6bcd4621d373cade4e832627b4f6",
-         "success":true,
-         "error":"msg"
+         "uuid": "f5e465ca-543e-44f5-9045-aebce6eb9ac3",
+         "file_name": "read1.fq",
+         "cloud_url": "s3://{bucket_name}/{sub_uuid}/read1.fq",
+         "size": 100,
+         "compressed": true,
+         "md5": "098f6bcd4621d373cade4e832627b4f6",
+         "ena_upload_path": "{env}/{sub_uuid}/read1.fq.gz",
+         "success": true,
+         "error": null
       },
       {
-         "file_name":"read2.fq",
-         "md5":"ad0234829205b9033196ba818f7a872b",
-         "success":true,
-         "error":"msg"
-      }
+         "uuid": "4320dc71-ac5f-4cb3-b1d3-d9a253a59e3b",
+         "file_name": "read2.fq.gz",
+         "cloud_url": "s3://{bucket_name}/{sub_uuid}/read2.fq.gz",
+         "size": 100,
+         "compressed": false,
+         "md5": "098f6bcd4621d373cade4e832627b4f6",
+         "ena_upload_path": "{env}/{sub_uuid}/read2.fq.gz",
+         "success": true,
+         "error": null
+      },
+      ...
    ]
 }
 ```

--- a/data/archiver/archiver.py
+++ b/data/archiver/archiver.py
@@ -1,18 +1,17 @@
-import os
 import logging
 from data.archiver.aws_s3_client import AwsS3
 from data.archiver.ftp_uploader import FtpUploader
+from data.archiver.ingest_api import Ingest
 from data.archiver.stream import S3FTPStreamer
 from data.archiver.utils import compress, md5
 from data.archiver.dataclass import DataArchiverRequest, DataArchiverResult, FileResult
-from data.archiver.ingest_api import Ingest
 
 
 class Archiver:
 
-    def __init__(self):
-        self.ingest_api = Ingest()
-        self.aws_client = AwsS3()
+    def __init__(self, ingest_cli: Ingest, aws_cli: AwsS3):
+        self.ingest_cli = ingest_cli
+        self.aws_cli = aws_cli
         self.ftp = None
         
         self.logger = logging.getLogger(__name__)
@@ -20,21 +19,27 @@ class Archiver:
 
     def start(self, req: DataArchiverRequest):
         self.logger.info(req)
-        self.logger.info(f'Getting sequence files for submission {req.sub_uuid} from INGEST_API')
-        sequence_files = self.ingest_api.get_sequence_files(req.sub_uuid)
+        self.logger.info(f'Getting sequence files for submission {req.sub_uuid} from Ingest.')
+        sequence_files = self.ingest_cli.get_sequence_files(req.sub_uuid)
         self.logger.info(sequence_files)
 
         if not sequence_files:
-            res = DataArchiverResult(req.sub_uuid, success=False, error='No sequence files in submission')
+            res = DataArchiverResult(req.sub_uuid, success=False, error='No sequence files in submission.')
             self.logger.info(res)
             return res
 
         if not req.files:
             # archive all files
-            res_files = list(map(lambda f: FileResult(f["file_name"], f["cloud_url"]), sequence_files))
+            res_files = list(map(lambda f: FileResult(f["uuid"], f["file_name"], f["cloud_url"]), sequence_files))
         else:
-            staging_area = self.ingest_api.get_staging_area()
-            res_files = list(map(lambda f: FileResult(f, staging_area + f), req.files))
+            def file_result(uuid):
+                for f in sequence_files:
+                    if f["uuid"] == uuid:
+                        return FileResult(f["uuid"], f["file_name"], f["cloud_url"])
+                return FileResult(uuid, None, None, success=False, error="File not found in Ingest.")
+
+            #staging_area = self.ingest_cli.get_staging_area()
+            res_files = list(map(file_result, req.files))
         
         res = DataArchiverResult(req.sub_uuid, files=res_files)
         self.logger.info(res)
@@ -54,7 +59,7 @@ class Archiver:
     def archive_files_via_localcopy(self, res: DataArchiverResult):
 
         self.logger.info(f'# step 1 download sequence files from S3')
-        self.aws_client.get_files(res)
+        self.aws_cli.get_files(res)
 
         self.logger.info(f'# step 2 compress files using gz')
         def try_compress(file):
@@ -65,6 +70,7 @@ class Archiver:
                 try:
                     compress(file)
                     file.file_name = f'{file.file_name}.gz'
+                    file.compressed = True
                 except:
                     file.success = False
                     file.error = 'Compression failed'
@@ -108,7 +114,7 @@ class Archiver:
         return res
 
     def close(self):
-        self.ingest_api.close()
-        #self.aws_client.close()
+        self.ingest_cli.close()
+        #self.aws_cli.close()
         if self.ftp:
             self.ftp.close()

--- a/data/archiver/archiver.py
+++ b/data/archiver/archiver.py
@@ -30,15 +30,14 @@ class Archiver:
 
         if not req.files:
             # archive all files
-            res_files = list(map(lambda f: FileResult(f["uuid"], f["file_name"], f["cloud_url"]), sequence_files))
+            res_files = list(map(FileResult.from_file, sequence_files))
         else:
             def file_result(uuid):
                 for f in sequence_files:
                     if f["uuid"] == uuid:
                         return FileResult(f["uuid"], f["file_name"], f["cloud_url"])
-                return FileResult(uuid, None, None, success=False, error="File not found in Ingest.")
+                return FileResult.not_found_error(uuid)
 
-            #staging_area = self.ingest_cli.get_staging_area()
             res_files = list(map(file_result, req.files))
         
         res = DataArchiverResult(req.sub_uuid, files=res_files)
@@ -115,6 +114,5 @@ class Archiver:
 
     def close(self):
         self.ingest_cli.close()
-        #self.aws_cli.close()
         if self.ftp:
             self.ftp.close()

--- a/data/archiver/aws_s3_client.py
+++ b/data/archiver/aws_s3_client.py
@@ -59,13 +59,15 @@ class AwsS3:
 
         total_size = 0
         for file in res.files:
+            if not file.success:
+                continue
 
             exists, size = self.file_exists(S3Url(file.cloud_url))
             if exists:
                 total_size += size
                 file.size = size
             else:
-                file.error = 'File not found.'
+                file.error = 'File not found in S3.'
                 file.success = False
         
         def download(file):

--- a/data/archiver/dataclass.py
+++ b/data/archiver/dataclass.py
@@ -22,12 +22,6 @@ class DataArchiverRequest:
         except (KeyError, TypeError) as e:
             raise DataArchiverRequestParseExpection(e)
 
-"""
-needed to make these changes as part of #669
-- using file uuid instead of name in ingest-data-archiver request
-- patch file document with data archiving result including ena_upload_path, md5 information, any error
-
-"""
 
 @dataclass
 class FileResult:

--- a/data/archiver/dataclass.py
+++ b/data/archiver/dataclass.py
@@ -46,6 +46,14 @@ class FileResult:
         self.success = success
         self.error = error
 
+    @classmethod
+    def from_file(cls, file):
+        return cls(file["uuid"], file["file_name"], file["cloud_url"])
+
+    @classmethod
+    def not_found_error(cls, uuid):
+        return cls(uuid, None, None, success=False, error="File not found in Ingest.")
+
 
 @dataclass
 class DataArchiverResult:

--- a/data/archiver/dataclass.py
+++ b/data/archiver/dataclass.py
@@ -52,7 +52,7 @@ class FileResult:
 
     @classmethod
     def not_found_error(cls, uuid):
-        return cls(uuid, None, None, success=False, error="File not found in Ingest.")
+        return cls(uuid, file_name=None, cloud_url=None, success=False, error="File not found in Ingest.")
 
 
 @dataclass

--- a/data/archiver/ingest_api.py
+++ b/data/archiver/ingest_api.py
@@ -70,31 +70,24 @@ class Ingest:
     def get_all(self, url, entity_type, entities=[]):
         response = self.session.get(url)
         response.raise_for_status()
-        if "_embedded" in response.json():
-            entities += response.json()["_embedded"][entity_type]
+        json_response = response.json()
+        if "_embedded" in json_response:
+            entities += json_response["_embedded"][entity_type]
 
-            if "next" in response.json()["_links"]:
-                url = response.json()["_links"]["next"]["href"]
+            if "next" in json_response["_links"]:
+                url = json_response["_links"]["next"]["href"]
                 self.get_all(url, entity_type, entities)
         return entities
 
-    #@handle_exception
     def patch_files(self, files: [FileResult]):
         for file in files:
             if not file.success:
                 continue
-            response = self.session.get(f'{INGEST_API}files/search/findByUuid?uuid={file.uuid}')
+            params = {'uuid': file.uuid}
+            response = self.session.get(f'{INGEST_API}files/search/findByUuid', params=params)
             if response.status_code == HTTPStatus.OK:
                 file_url = response.json()["_links"]["self"]["href"]
-                archive_result = {
-                    "fileArchiveResult": {
-                        "lastArchived":  datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                        "compressed": file.compressed,
-                        "md5": file.md5,
-                        "enaUploadPath": file.ena_upload_path,
-                        "error": file.error
-                    }
-                }
+                archive_result = Ingest.archive_result_from_filemeta(file)
                 patch_response = self.session.patch(file_url, json.dumps(archive_result), headers={ 'Content-type':'application/json' })
                 if patch_response.status_code == HTTPStatus.ACCEPTED:
                     self.logger.info(f"Patched {file_url} {archive_result}")
@@ -103,6 +96,17 @@ class Ingest:
             else:
                 self.logger.info(f"Could not get {file_url}: {response.status_code} ")
 
+    @staticmethod
+    def archive_result_from_filemeta(file):
+        return {
+            "fileArchiveResult": {
+                "lastArchived": datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "compressed": file.compressed,
+                "md5": file.md5,
+                "enaUploadPath": file.ena_upload_path,
+                "error": file.error
+            }
+        }
 
     def close(self):
         self.session.close()

--- a/data/archiver/listener.py
+++ b/data/archiver/listener.py
@@ -50,20 +50,12 @@ class _Listener(ConsumerProducerMixin):
             error_msg = f'Invalid data archiving request: {body}'
             self.logger.info(error_msg)
             result = DataArchiverResult(req.sub_uuid, success=False, error=error_msg)
-            #self.logger.exception(e)
+
         except Exception as e:
             error_msg = f'Data archiving request failed: {body}'
             self.logger.info(error_msg)
             result = DataArchiverResult(req.sub_uuid, success=False, error=error_msg)
-            #self.logger.exception(e)
 
-        #self.producer.publish(result.to_dict(),
-        #    exchange=self.pub_queue_config.exchange,
-        #    routing_key=self.pub_queue_config.routing_key,
-        #    retry=self.pub_queue_config.retry,
-        #    retry_policy=self.pub_queue_config.retry_policy)
-        
-        #ingest_cli.patch_submission(result)
         ingest_cli.patch_files(result.files)
 
         msg.ack()

--- a/tests/e2e/test_archiver.py
+++ b/tests/e2e/test_archiver.py
@@ -56,7 +56,6 @@ class TestArchiver(unittest.TestCase):
         with patch('data.archiver.archiver.Ingest') as mock:
             mock_ingest = mock.return_value
             mock_ingest.get_sequence_files.return_value = [{"uuid": self.file_uuid, "file_name": self.file_name, "cloud_url": f's3://{self.s3_file}'}]
-            #mock_ingest.get_staging_area.return_value = f's3://{TEST_BUCKET}/{self.sub_uuid}/'
 
             self.logger.info(f'Starting data archiver ')
             req = DataArchiverRequest.from_dict({"sub_uuid": f"{self.sub_uuid}", "files": [ f"{self.file_uuid}" ]}) 

--- a/tests/e2e/test_archiver.py
+++ b/tests/e2e/test_archiver.py
@@ -3,18 +3,21 @@ import sys
 import s3fs
 import uuid
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 import tempfile
 import logging
 import random
 from ftplib import FTP
 from data.archiver.archiver import Archiver
+from data.archiver.aws_s3_client import AwsS3
 from data.archiver.dataclass import DataArchiverRequest
 from data.archiver.config import AWS_ACCESS_KEY, AWS_SECRET_KEY, ENA_FTP_DIR, ENA_FTP_HOST, ENA_WEBIN_USER, ENA_WEBIN_PWD
 from data.archiver.ftp_uploader import FtpUploader
+from data.archiver.ingest_api import Ingest
 
 TEST_BUCKET = "org-hca-data-archive-upload-dev"
 
+# TODO move this to the integration tests suite as not all dep components are mocked.
 class TestArchiver(unittest.TestCase):
 
     def setUp(self):
@@ -34,6 +37,7 @@ class TestArchiver(unittest.TestCase):
         file_size = random.randint(1024, 1024*1024) # in bytes (between 1Kb and 1Mb)
         self.tmp_file = tempfile.NamedTemporaryFile()
         self.tmp_file.write(os.urandom(file_size))
+        self.file_uuid = str(uuid.uuid4())
         self.file_name = os.path.basename(self.tmp_file.name)
         self.logger.info(f'Temp file: {self.tmp_file.name} {file_size} bytes')
 
@@ -48,21 +52,21 @@ class TestArchiver(unittest.TestCase):
         super().setUp()
 
     def test_archive(self):
-        self.logger.info(f'Mocking ingest service as this submission is not in Ingest')
+        self.logger.info(f'Mocking ingest service as Ingest will not contain test submission')
         with patch('data.archiver.archiver.Ingest') as mock:
             mock_ingest = mock.return_value
-            mock_ingest.get_sequence_files.return_value = [{"file_name": self.file_name, "cloud_url": f's3://{self.s3_file}'}]
-            mock_ingest.get_staging_area.return_value = f's3://{TEST_BUCKET}/{self.sub_uuid}/'
+            mock_ingest.get_sequence_files.return_value = [{"uuid": self.file_uuid, "file_name": self.file_name, "cloud_url": f's3://{self.s3_file}'}]
+            #mock_ingest.get_staging_area.return_value = f's3://{TEST_BUCKET}/{self.sub_uuid}/'
 
             self.logger.info(f'Starting data archiver ')
-            req = DataArchiverRequest.from_dict({"sub_uuid": f"{self.sub_uuid}", "files": [ f"{self.file_name}" ]}) 
-            archiver = Archiver()
+            req = DataArchiverRequest.from_dict({"sub_uuid": f"{self.sub_uuid}", "files": [ f"{self.file_uuid}" ]}) 
+            archiver = Archiver(mock_ingest, AwsS3())
             archiver.start(req)
             archiver.close()
 
-            self.logger.info(f'Finish. Checking expected files in FTP location.')
-            assert FtpUploader.file_exists(self.ftp, f'{self.file_name}.gz') == True
-            assert FtpUploader.file_exists(self.ftp, f'{self.file_name}.gz.md5') == True
+        self.logger.info(f'Finish. Checking expected files in FTP location.')
+        assert FtpUploader.file_exists(self.ftp, f'{self.file_name}.gz') == True
+        assert FtpUploader.file_exists(self.ftp, f'{self.file_name}.gz.md5') == True
 
     def tearDown(self):
         self.logger.info('Local clean up')


### PR DESCRIPTION
Changes:
- Update data archiver request to take file uuid instead of file name
- Update data archiver response to include additional information including md5, whether file was compressed during archiving and the ena upload path
- Patch file document with `fileArchiveResult`