### PR TITLE
[dcp-725] data archiver message comes as a JSON dict and not as a string

### DIFF
--- a/data/archiver/listener.py
+++ b/data/archiver/listener.py
@@ -32,14 +32,13 @@ class _Listener(ConsumerProducerMixin):
                                         prefetch_count=1)
         return [consumer]
     
-    def data_archiver_message_handler(self, body: str, msg: Message):
+    def data_archiver_message_handler(self, body: dict, msg: Message):
         return self.executor.submit(lambda: self._data_archiver_message_handler(body, msg))
 
-    def _data_archiver_message_handler(self, body: str, msg: Message):
+    def _data_archiver_message_handler(self, body: dict, msg: Message):
         ingest_cli = Ingest()
         try:
-            dict = json.loads(body)
-            req = DataArchiverRequest.from_dict(dict)
+            req = DataArchiverRequest.from_dict(body)
             self.logger.info(f'Received data archiving request for submission uuid {req.sub_uuid}')
 
             result = Archiver(ingest_cli, AwsS3()).start(req)            


### PR DESCRIPTION
dcp-725

Changes:
- Data archiver message from the message queue comes as a dict (JSON serialised value) and not as a string